### PR TITLE
Native Audio Player Fix

### DIFF
--- a/tumbleplate1.0/index.html
+++ b/tumbleplate1.0/index.html
@@ -177,6 +177,8 @@
         	{block:Audio}
         		<div class="post audio">
             	{AudioEmbed}
+            	{block:AudioPlayer}
+            	{AudioPlayer}{/block:AudioPlayer}
             	{block:Caption}
             		<div class="caption">{Caption}</div>
             	{/block:Caption}


### PR DESCRIPTION
The traditional audio posts (uploaded audio) didn't work. I'm pretty sure that fixes it, it's a fallback to the native player (http://www.tumblr.com/docs/en/custom_themes#audio-posts).